### PR TITLE
Invalid Group Resource

### DIFF
--- a/src/classes/BoxGroup.cls
+++ b/src/classes/BoxGroup.cls
@@ -4,8 +4,8 @@
 
 public class BoxGroup extends BoxCollaborator {
 
-    private static final String CREATE_GROUP_URL = '/groups';
-    private static final String GROUP_INFO_URL = '/groups/{0}';
+    private static final String CREATE_GROUP_URL = 'groups';
+    private static final String GROUP_INFO_URL = 'groups/{0}';
 
     /**
      * Constructs a BoxGroup for a group with a given ID.


### PR DESCRIPTION
removed '/' from the resource string as the api.baseUrl already has and ending '/'
